### PR TITLE
Let CP environment be set in OS environment

### DIFF
--- a/server.py
+++ b/server.py
@@ -43,7 +43,6 @@ class DeadParrot:
             'global': {
                 'server.socket_host': '::0',
                 'server.socket_port': int(os.environ.get('PORT', 8080)),
-                'environment': 'production',
             },
             '/': {
                 'request.dispatch': cherrypy.dispatch.MethodDispatcher(),

--- a/server.py
+++ b/server.py
@@ -43,6 +43,7 @@ class DeadParrot:
             'global': {
                 'server.socket_host': '::0',
                 'server.socket_port': int(os.environ.get('PORT', 8080)),
+                'environment': os.environ.get('CP_ENVIRONMENT', 'production'),
             },
             '/': {
                 'request.dispatch': cherrypy.dispatch.MethodDispatcher(),


### PR DESCRIPTION
I needed to run a version of this which generated output logs (instead of being silent). Being able to influence the CherryPy environment in use allowed me to do that.